### PR TITLE
[ESV-7764] feat: add discriminator to help consumers detect the object type

### DIFF
--- a/tarifierung-api.yaml
+++ b/tarifierung-api.yaml
@@ -554,7 +554,9 @@ components:
             - $ref: "#/components/schemas/EventOccupationCodeSubmitted"
             - $ref: "#/components/schemas/EventIscoOccupationTypeChanged"
             - $ref: "#/components/schemas/EventGrossPremiumChanged"
-    
+          discriminator:
+            propertyName: eventType
+
     EventId:
       description: Identifikator für einen Event.
       type: string
@@ -570,8 +572,12 @@ components:
         Ergebnis zu "Einreichen eines Berufscodes".
       type: object
       properties:
+        eventType:
+          type: string
         occupation:
           $ref: "#/components/schemas/OccupationCode"
+      required:
+        - eventType
     
     EventIscoOccupationTypeChanged:
       description: >-
@@ -579,20 +585,28 @@ components:
         Tätigkeiten mit dem geänderten Risiko erhalten potentiell anderen Prämiensätze.
       type: object
       properties:
+        eventType:
+          type: string
         premiumYear:
           $ref: "#/components/schemas/PremiumYear"
         iscoOccupationType:
           $ref: "#/components/schemas/IscoOccupationType"
+      required:
+        - eventType
     
     EventGrossPremiumChanged:
       description: >-
         Von der Suva wurden für einen Betriebsteil neue Prämiensätze verfügt.
       type: object
       properties:
+        eventType:
+          type: string
         premiumYear:
           $ref: "#/components/schemas/PremiumYear"
         businessUnitCode:
           $ref: "#/components/schemas/BusinessUnitCode"
+      required:
+        - eventType
 
     # commons
 


### PR DESCRIPTION
Ohne `discriminator` werden nicht alle benötigten Jackson Annotations (z. Bsp. `JsonSubTypes`) für die verschiedenen EventDetail Dtos generiert und Jackson kann dann die Events nicht richtig serialisieren weil Type Information fehlt. 
Beim `v1/events` Endpoint gibt es keine Probleme, weil wir da eine List zurückgeben..