### PR TITLE
feat: Removed min-length of descriptions on OccupationCodeDto to prevent validation errors

### DIFF
--- a/berufscode-api.yaml
+++ b/berufscode-api.yaml
@@ -529,7 +529,6 @@ components:
           $ref: "#/components/schemas/OccupationCodeNr"
         descriptions:
           type: array
-          minItems: 1
           items:
             $ref: "#/components/schemas/OccupationDescription"
         suvaOccupationCode:


### PR DESCRIPTION
Beim Generieren des Dtos wird 
`@Size(min = 1)`
weggelassen. Die Initialisierung funktioniert wie bis anhin, deshalb muss beim Service nur noch der Contract aktualisiert, aber keine Anpassung im Code vorgenommen werden.

minItems wurde zudem noch auf z. 206 (post OccupationDescription.descriptions, befindet sich im Requestparameter und ist als required gekennzeichnet), 477 (SuvaOccupationCode.descriptions, ist als required attribut definiert und deswegen macht es auch Sinn, dass mindestens ein Element geliefert werden sollte) und 588  (in OperatingUnitTemporalProfile.descriptions -> Endpunkt noch nicht implementiert) gefunden.