### PR TITLE
[ESV-8990] feat: renamed iscoCode to iscoOccupationTypeId

### DIFF
--- a/lohnmeldung-api.yaml
+++ b/lohnmeldung-api.yaml
@@ -2146,7 +2146,7 @@ components:
           type: string
           example: "A"
           pattern: "^[A-Z]$"
-        iscoCode:
+        iscoOccupationTypeId:
           description: |
             🇩🇪 ISCO-Berufsart
             🇬🇧 ISCO occupation type
@@ -2198,7 +2198,7 @@ components:
       required:
         - iscoSalaryNumber
         - companyPartCode
-        - iscoCode
+        - iscoOccupationTypeId
         - buNbuApAnpCode
         - uvgLaaGrossSalary
         - uvgLaaBaseSalary


### PR DESCRIPTION
`iscoCode` renamed zu `iscoOccupationTypeId` damit die ISCO Berufsart überall gleich heisst